### PR TITLE
Improve support for e notation floats using integer number (e.g. 1e-05)

### DIFF
--- a/internal/parser/commons_test.go
+++ b/internal/parser/commons_test.go
@@ -17,8 +17,8 @@ func assertField(t *testing.T, field *GdField, key string, values ...interface{}
 	}
 
 	switch field.Value.Raw().(type) {
-	case *GdType:
-		typeVal, ok := field.Value.Raw().(*GdType)
+	case GdType:
+		typeVal, ok := field.Value.Raw().(GdType)
 		assert.True(t, ok)
 		assert.Equal(t, values[0], typeVal.Key)
 		assert.Equal(t, len(values)-1, len(typeVal.Parameters))

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -10,6 +10,11 @@ import (
 
 var tscnLexer = lexer.MustSimple([]lexer.Rule{
 	{
+		Name:    "Float",
+		Pattern: `-?\d+(\.\d+|e-?\d+)(e-?\d+)?\b`,
+		Action:  nil,
+	},
+	{
 		Name:    "Ident",
 		Pattern: `([0-9]+)?/?[a-zA-Z_][a-zA-Z_\d/]*`,
 		Action:  nil,
@@ -17,11 +22,6 @@ var tscnLexer = lexer.MustSimple([]lexer.Rule{
 	{
 		Name:    "String",
 		Pattern: `"[^"]*"`,
-		Action:  nil,
-	},
-	{
-		Name:    "Float",
-		Pattern: `-?[0-9]*\.[0-9]+(e\-[0-9]+)?\b`,
 		Action:  nil,
 	},
 	{

--- a/internal/parser/parser_test.go
+++ b/internal/parser/parser_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestParseFail(t *testing.T) {
@@ -230,6 +231,15 @@ func TestReferenceTypeWithKeyValuePairs(t *testing.T) {
 reference_type = Object(InputEventKey,"resource_local_to_scene":false,"resource_name":"","device":0,"alt":false)`
 	_, err := Parse(strings.NewReader(content))
 	assert.NoError(t, err)
+}
+
+func TestScientificENotation(t *testing.T) {
+	content := `[gd_scene]
+scientific_e_float = 1e-05`
+
+	scene, err := Parse(strings.NewReader(content))
+	require.NoError(t, err)
+	assertField(t, scene.Fields[0], "scientific_e_float", 1e-05)
 }
 
 // keep regression tests at the bottom please (above integration tests though)


### PR DESCRIPTION
Provides a fix for #6 by making the regular expression more liberal in matching floats, and moving it up before the `Ident` rule to make sure the most specific wins.

The regular expression is not perfect because it will also match `1e-05e05` for example. But this is the best I could come up with, without the use of look-aheads perhaps. Personally I think this an acceptable solution since `.tscn`s are unlikely written by hand and such errors **should** thus be uncommon.

What do you think?

P.S. I've noticed the `TestParseFileDescriptorFields` test never reaches any of the other fields because it `continue`s before it gets to after `negative_int_field`. I think the test could be improved by using a `switch` and `t.Run(field)`. If you agree, I can include that in this PR and move the new `TestScientificENotation` test to that one as well?

Fixes #6